### PR TITLE
Remove useless dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "1.*",
-        "codeception/codeception": "^2.4",
-        "baka/auth": "^0.1",
-        "baka/database": "~0.1",
-        "vlucas/phpdotenv": "^2.4"
+        "codeception/codeception": "^2.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
If those dependencies are in the required segment, is not necessary to write them again in require dev section.